### PR TITLE
Fixed crash on import in Python 3.5

### DIFF
--- a/dlipr/cifar.py
+++ b/dlipr/cifar.py
@@ -45,7 +45,7 @@ try:
     # python 2
     import cPickle as pickle
     _pickle_kwargs = {}
-except ModuleNotFoundError:
+except ImportError:
     # python 3
     import pickle
     _pickle_kwargs = {'encoding': 'latin1'}


### PR DESCRIPTION
Crashed when imported in Python 3.5:
NameError: name 'ModuleNotFoundError' is not defined